### PR TITLE
Allow plugin to work with any game

### DIFF
--- a/GameZen.plugin.js
+++ b/GameZen.plugin.js
@@ -48,7 +48,6 @@ const ERRORS = {
 };
 
 const SETTINGS = {
-  gameName: "Game Name",
   checkIntervalInSeconds: 10,
 };
 
@@ -91,27 +90,6 @@ module.exports = class GameZen {
   }
 
   /**
-   * Checks if the user is currently playing the game specified in the `SETTINGS.gameName` property.
-   * @param {Array} activities - An array of user activities.
-   * @returns {boolean} - Returns `true` if the user is playing the game specified in `SETTINGS.gameName`, otherwise returns `false`.
-   */
-  isGameActivity(activities) {
-    if (
-      typeof SETTINGS.gameName !== "string" ||
-      SETTINGS.gameName.trim() === ""
-    ) {
-      console.error(ERRORS.INVALID_GAME_NAME, SETTINGS.gameName);
-      return false;
-    }
-    for (const activity in activities) {
-      if (activities[activity].name === SETTINGS.gameName) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
    * Updates the user status to "dnd".
    */
   updateToDnd() {
@@ -148,7 +126,8 @@ module.exports = class GameZen {
       ).getLocalPresence;
 
       this.intervalId = setInterval(() => {
-        if (this.isGameActivity(this.getLocalPresence().activities)) {
+        const runningGames = BdApi.Webpack.getStore("RunningGameStore").getRunningGames();
+        if (runningGames.length > 0) {
           if (this.currentStatus() !== "dnd") {
             this.currentUserStatus = this.currentStatus();
             this.updateToDnd();
@@ -158,7 +137,7 @@ module.exports = class GameZen {
         }
         if (
           this.currentStatus() !== this.currentUserStatus &&
-          !this.isGameActivity(this.getLocalPresence().activities)
+          runningGames.length == 0
         ) {
           this.currentUserStatus = this.currentStatus();
         }
@@ -225,21 +204,13 @@ module.exports = class GameZen {
     const SettingsPanel = document.createElement("div");
     SettingsPanel.id = "settings";
 
-    const gameName = this.buildSetting(
-      "Game Name",
-      "gameName",
-      "text",
-      SETTINGS.gameName
-    );
-
     const checkIntervalInSeconds = this.buildSetting(
       "Check Interval (in seconds)",
       "checkIntervalInSeconds",
       "number",
       SETTINGS.checkIntervalInSeconds
     );
-
-    SettingsPanel.append(gameName);
+    
     SettingsPanel.append(checkIntervalInSeconds);
     return SettingsPanel;
   }

--- a/GameZen.plugin.js
+++ b/GameZen.plugin.js
@@ -126,8 +126,8 @@ module.exports = class GameZen {
       ).getLocalPresence;
 
       this.intervalId = setInterval(() => {
-        const runningGames = BdApi.Webpack.getStore("RunningGameStore").getRunningGames();
-        if (runningGames.length > 0) {
+        const primaryActivity = BdApi.Webpack.getStore("LocalActivityStore").getPrimaryActivity();
+        if (primaryActivity) {
           if (this.currentStatus() !== "dnd") {
             this.currentUserStatus = this.currentStatus();
             this.updateToDnd();
@@ -137,7 +137,7 @@ module.exports = class GameZen {
         }
         if (
           this.currentStatus() !== this.currentUserStatus &&
-          runningGames.length == 0
+          !primaryActivity
         ) {
           this.currentUserStatus = this.currentStatus();
         }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## 📍 Overview
 
-The GameZen plugin is a BetterDiscord plugin that aims to enhance the user experience by automatically activating Do Not Disturb mode and updating the user status when a specified game is launched. By providing a settings panel, users are able to customize the game name and check interval, making it a flexible and personalized solution for gamers on Discord. Its core value proposition lies in its ability to enhance productivity and immersion during gaming sessions by managing notifications effectively.
+The GameZen plugin is a BetterDiscord plugin that aims to enhance the user experience by automatically activating Do Not Disturb mode and updating the user status when any game is launched. By providing a settings panel, users are able to customize the check interval, making it a flexible and personalized solution for gamers on Discord. Its core value proposition lies in its ability to enhance productivity and immersion during gaming sessions by managing notifications effectively.
 
 ---
 
@@ -56,7 +56,7 @@ The GameZen plugin is a BetterDiscord plugin that aims to enhance the user exper
 
 | File                                                                                   | Summary                                                                                                                                                                                                                                                               |
 | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [GameZen.plugin.js](https://github.com/TheoEwzZer/GameZen/blob/main/GameZen.plugin.js) | The code is for a BetterDiscord plugin called GameZen. It automatically activates Do Not Disturb mode when a specified game is launched, and updates the user status accordingly. It also provides a settings panel for customizing the game name and check interval. |
+| [GameZen.plugin.js](https://github.com/TheoEwzZer/GameZen/blob/main/GameZen.plugin.js) | The code is for a BetterDiscord plugin called GameZen. It automatically activates Do Not Disturb mode when a game is launched, and updates the user status accordingly. It also provides a settings panel for customizing the check interval. |
 
 </details>
 


### PR DESCRIPTION
Hi thanks for making this plugin, it was driving me crazy Discord didn't offer this functionality out of the box. However at first your plugin didn't work and I realised you needed to enter the game name. That would be rather inconvenient so I've updated the plugin to set DnD for any detected game. 